### PR TITLE
Support multiple prefixes.

### DIFF
--- a/src/main/kotlin/org/randomcat/agorabot/commands/Prefix.kt
+++ b/src/main/kotlin/org/randomcat/agorabot/commands/Prefix.kt
@@ -18,38 +18,69 @@ class PrefixCommand(
     private val prefixMap: MutableGuildPrefixMap,
 ) : BaseCommand(strategy) {
     override fun BaseCommandImplReceiver.impl() {
-        matchFirst {
-            noArgs {
-                val guildId = currentGuildInfo()?.guildId ?: run {
-                    respondNeedGuild()
-                    return@noArgs
-                }
+        subcommands {
+            subcommand("list") {
+                noArgs {
+                    val guildId = currentGuildInfo()?.guildId ?: run {
+                        respondNeedGuild()
+                        return@noArgs
+                    }
 
-                respond("The prefix is: ${prefixMap.prefixForGuild(guildId)}")
+                    val prefixes = prefixMap.prefixesForGuild(guildId).joinToString { "`${it}`" }
+                    respond("The following prefixes can be used: ${prefixes}")
+                }
             }
 
-            args(
-                StringArg("new_prefix"),
-            ).permissions(
-                GuildScope.command("prefix").action("set"),
-            ) { (newPrefix) ->
-                val guildId = currentGuildInfo()?.guildId ?: run {
-                    respondNeedGuild()
-                    return@permissions
-                }
+            subcommand("add") {
+                args(
+                    StringArg("new_prefix"),
+                ).permissions(
+                    GuildScope.command("prefix").action("set"),
+                ) { (newPrefix) ->
+                    val guildId = currentGuildInfo()?.guildId ?: run {
+                        respondNeedGuild()
+                        return@permissions
+                    }
 
-                if (newPrefix.isBlank()) {
-                    respond("The prefix cannot be empty. Stop it.")
-                    return@permissions
-                }
+                    if (newPrefix.isBlank()) {
+                        respond("The prefix cannot be empty. Stop it.")
+                        return@permissions
+                    }
 
-                if (newPrefix.any { PROHIBITED_CATEGORIES.contains(it.category) }) {
-                    respond("The specified prefix contains an illegal character.")
-                    return@permissions
-                }
+                    if (newPrefix.any { PROHIBITED_CATEGORIES.contains(it.category) }) {
+                        respond("The specified prefix contains an illegal character.")
+                        return@permissions
+                    }
 
-                prefixMap.setPrefixForGuild(guildId, newPrefix)
-                respond("The prefix has been updated.")
+                    if(prefixMap.prefixesForGuild(guildId).contains(newPrefix)) {
+                        respond("That's already a prefix.")
+                        return@permissions
+                    }
+
+                    prefixMap.addPrefixForGuild(guildId, newPrefix)
+                    respond("The prefix has been added.")
+                }
+            }
+
+            subcommand("remove") {
+                args(
+                    StringArg("prefix"),
+                ).permissions(
+                    GuildScope.command("prefix").action("set"),
+                ) { (newPrefix) ->
+                    val guildId = currentGuildInfo()?.guildId ?: run {
+                        respondNeedGuild()
+                        return@permissions
+                    }
+
+                    if(!prefixMap.prefixesForGuild(guildId).contains(newPrefix)) {
+                        respond("That's not a prefix.")
+                        return@permissions
+                    }
+
+                    prefixMap.removePrefixForGuild(guildId, newPrefix)
+                    respond("The prefix has been removed.")
+                }
             }
         }
     }

--- a/src/main/kotlin/org/randomcat/agorabot/listener/CommandParser.kt
+++ b/src/main/kotlin/org/randomcat/agorabot/listener/CommandParser.kt
@@ -51,11 +51,12 @@ fun parsePrefixListCommand(prefixOptions: Iterable<String>, message: String): Co
 }
 
 interface GuildPrefixMap {
-    fun prefixForGuild(guildId: String): String
+    fun prefixesForGuild(guildId: String): Iterable<String>
 }
 
 interface MutableGuildPrefixMap : GuildPrefixMap {
-    fun setPrefixForGuild(guildId: String, prefix: String)
+    fun addPrefixForGuild(guildId: String, prefix: String)
+    fun removePrefixForGuild(guildId: String, prefix: String)
 }
 
 class GlobalPrefixCommandParser(private val prefix: String) : CommandParser {
@@ -66,8 +67,8 @@ class GlobalPrefixCommandParser(private val prefix: String) : CommandParser {
 }
 
 class GuildPrefixCommandParser(private val map: GuildPrefixMap) : CommandParser {
-    override fun parse(event: MessageReceivedEvent): CommandParseResult = parsePrefixCommand(
-        prefix = map.prefixForGuild(event.guild.id),
+    override fun parse(event: MessageReceivedEvent): CommandParseResult = parsePrefixListCommand(
+        prefixOptions = map.prefixesForGuild(event.guild.id),
         message = event.message.contentRaw,
     )
 }


### PR DESCRIPTION
Clearly, this is a very important and useful feature, and not just an opportunity for silly Agoran memeing.

Note that I couldn't be bothered to automatically migrate the prefixes file, so you'll have to manually change `{"123456789": "HEY BOT!"}` to `{"123456789": ["HEY BOT!"]}`.